### PR TITLE
chore: update shas

### DIFF
--- a/kustomize/application/jupyter-web-app/configs/spawner_ui_config.yaml
+++ b/kustomize/application/jupyter-web-app/configs/spawner_ui_config.yaml
@@ -18,14 +18,14 @@ spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
     # If readonly, this value must be a member of the list below
-    value: k8scc01covidacr.azurecr.io/jupyterlab-cpu:a3870fcc
+    value: k8scc01covidacr.azurecr.io/jupyterlab-cpu:1b5c3b61
     # The list of available standard container Images
     options:
-      - k8scc01covidacr.azurecr.io/jupyterlab-cpu:a3870fcc
-      - k8scc01covidacr.azurecr.io/rstudio:a3870fcc
-      - k8scc01covidacr.azurecr.io/remote-desktop:a3870fcc
-      - k8scc01covidacr.azurecr.io/jupyterlab-pytorch:a3870fcc
-      - k8scc01covidacr.azurecr.io/jupyterlab-tensorflow:a3870fcc
+      - k8scc01covidacr.azurecr.io/jupyterlab-cpu:1b5c3b61
+      - k8scc01covidacr.azurecr.io/rstudio:1b5c3b61
+      - k8scc01covidacr.azurecr.io/remote-desktop:1b5c3b61
+      - k8scc01covidacr.azurecr.io/jupyterlab-pytorch:1b5c3b61
+      - k8scc01covidacr.azurecr.io/jupyterlab-tensorflow:1b5c3b61
     # By default, custom container Images are allowed
     # Uncomment the following line to only enable standard container Images
     readOnly: false


### PR DESCRIPTION
Update to the most recent version of [aaw-kubeflow-containers](https://github.com/StatCan/aaw-kubeflow-containers/commit/d1a6b8c99ae93a4e0ef3a4415a2e4acd2dfa317c)
Included in this update are vulnerability fixes, the _removal_ of the download button in VSCode and auto-configure to point to our Artifactory.


At the moment however we don't have the settings in place for prod to connect to Artifactory (dev can)